### PR TITLE
Tweak LCSH subject metadata

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -28,7 +28,9 @@
 		<link href="onix.xml" media-type="application/xml" properties="onix" rel="record"/>
 		<dc:title id="title">The Cosmic Computer</dc:title>
 		<meta property="file-as" refines="#title">Cosmic Computer, The</meta>
-		<dc:subject id="subject">Science fiction</dc:subject>
+		<dc:subject id="subject-1">Science fiction</dc:subject>
+		<meta property="authority" refines="#subject-1">LCSH</meta>
+		<meta property="term" refines="#subject-1">sh85118629</meta>
 		<meta property="se:subject">Science Fiction</meta>
 		<meta id="collection-1" property="belongs-to-collection">Federation</meta>
 		<meta property="collection-type" refines="#collection-1">series</meta>


### PR DESCRIPTION
1. `id` should be `subject-1`, not `subject`
2. If I understand the manual correctly, even though the subject came from PG (there’s no LOC entry), it still needs the LCSH authority block.